### PR TITLE
Support Windows by using lein.bat as the shell command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 /.lein-deps-sum
 *~
 out.txt
+/bin/

--- a/README.textile
+++ b/README.textile
@@ -18,15 +18,15 @@ h1. Usage
 
 See "Leiningen: Installing Plugins":https://github.com/technomancy/leiningen/wiki/Upgrading#plugins
 
-Add @[lein-release "1.0.5"]@ to the @:user -> :plugins@ section of your @$HOME/.lein/profiles.clj@:
+Add @[lein-release "1.0.10"]@ to the @:user -> :plugins@ section of your @$HOME/.lein/profiles.clj@:
 
 <pre>
-{:user {:plugins [[lein-release "1.0.5"]]}}
+{:user {:plugins [[lein-release "1.0.10"]]}}
 </pre>
 
 For Leiningen 1:
 
-pre.    lein plugin install lein-release/lein-release 1.0.5
+pre.    lein plugin install lein-release/lein-release 1.0.10
 
 To perform a release:
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-release/lein-release "1.0.9"
+(defproject lein-release/lein-release "1.0.10-SNAPSHOT"
   :description "Leiningen Release Plugin"
   :url         "https://github.com/relaynetwork/lein-release"
   :dev-dependencies [[swank-clojure "1.4.2"]]

--- a/src/leiningen/release.clj
+++ b/src/leiningen/release.clj
@@ -5,6 +5,11 @@
   (:import
    [java.util.regex Pattern]))
 
+(def lein-shell-cmd
+  (if (.startsWith (System/getProperty "os.name") "Windows")
+    "lein.bat"
+    "lein"))
+
 (def ^:dynamic config {})
 
 (defn raise [fmt & args]
@@ -149,13 +154,13 @@
   (case (detect-deployment-strategy project)
 
     :lein-deploy
-    (sh! "lein" "deploy")
+    (sh! lein-shell-cmd "deploy")
 
     :lein-install
-    (sh! "lein" "install")
+    (sh! lein-shell-cmd "install")
 
     :clojars
-    (sh! "lein" "deploy" "clojars")
+    (sh! lein-shell-cmd "deploy" "clojars")
 
     :shell
     (apply sh! (:shell config))
@@ -202,10 +207,10 @@
         (scm! :tag (format "%s-%s" (:name project) release-version)))
       (when-not (.exists (java.io.File. jar-file-name))
         (println "creating jar and pom files...")
-        (sh! "lein" "jar")
-        (sh! "lein" "pom"))
+        (sh! lein-shell-cmd "jar")
+        (sh! lein-shell-cmd "pom"))
       (when (-> project :lein-release :build-uberjar)
-        (sh! "lein" "uberjar"))
+        (sh! lein-shell-cmd "uberjar"))
       (perform-deploy! project jar-file-name)
       (when-not (is-snapshot? (extract-project-version-from-file))
         (println (format "updating version %s => %s for next dev cycle" release-version next-dev-version))


### PR DESCRIPTION
This is a simple refactoring to add some logic in order to switch the shell command from "lein" to "lein.bat" in order to support Windows